### PR TITLE
IE11’s blur event doesn’t have e.relatedTarget. Switching to focusout.

### DIFF
--- a/birch-typeahead.html
+++ b/birch-typeahead.html
@@ -124,7 +124,7 @@ Custom property | Description | Default
         on-keydown="_handleKeydown"
         on-input="_handleInput"
         on-focus="_handleFocus"
-        on-blur="_handleBlur"/>
+        on-focusout="_handleFocusout"/>
       <paper-menu id="optionsContainer" tabindex="-1" on-tap="_handleTap" hidden$="[[_hideOptions]]">
         <template is="dom-repeat" id="userTemplate" items="[[options]]"></template>
       </paper-menu>
@@ -350,7 +350,8 @@ Custom property | Description | Default
         if(this.showOptionsOnFocus && this.$.input.value) this._hideOptions = false;
       },
 
-      _handleBlur: function(e){
+      // Have to use focusout event becuase IE11's blur event doesn't have e.relatedTarget
+      _handleFocusout: function(e){
         var child = e.relatedTarget;
         var parent = this.$.optionsContainer;
         if(parent.contains(child)) return;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-typeahead",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "authors": [
     "Anonymous <anonymous@example.com>"
   ],

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <title>birch-typeahead Demo</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/1.0.0/fetch.min.js"></script>
     <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
     <script type="text/javascript">
       window.Polymer = {dom: 'shadow'};
@@ -111,6 +110,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             typeahead.options = entries;
           }
         });
+      });
+
+      typeahead.addEventListener('birch-typeahead:selected', function (e){
+        console.log('selected', e.detail.selection);
+      });
+
+      typeahead.addEventListener('birch-typeahead:blur', function (e){
+        console.log('blur');
       });
     </script>
   </body>


### PR DESCRIPTION
@jasonallen68 