### PR TITLE
Add 'disabled' attribute functionality and mixin

### DIFF
--- a/birch-typeahead.css
+++ b/birch-typeahead.css
@@ -40,6 +40,10 @@ paper-item > *, paper-icon-item > *, paper-item-body > * {
   @apply(--birch-typeahead-input);
 }
 
+#input[disabled] {
+  @apply --birch-typeahead-input-disabled;
+}
+
 #container {
   max-width: 300px;
   position: relative;

--- a/birch-typeahead.html
+++ b/birch-typeahead.html
@@ -97,6 +97,7 @@ Custom property | Description | Default
 `--birch-typeahead-paper-item-icon-width`   | Pass through `--paper-item-icon-width` | `25px`
 `--birch-typeahead-paper-menu`              | Pass through `--paper-menu`            | `{}`
 `--birch-typeahead-input`                   | Style birch-typeahead's input          | `{}`
+`--birch-typeahead-input-disabled`          | Style birch-typeahead's input when disabled         | `{}`
 `--birch-typeahead-options-z-index`         | z-index for the options paper-menu     | `200`
 
 @demo demo/index.html
@@ -120,6 +121,7 @@ Custom property | Description | Default
         value="{{value::input}}"
         placeholder$="[[placeholder]]"
         autofocus$="[[autofocus]]"
+        disabled$="[[disabled]]"
         class$="[[_class('loading', loading)]]"
         on-keydown="_handleKeydown"
         on-input="_handleInput"
@@ -239,6 +241,15 @@ Custom property | Description | Default
          * Input autofocus value
          */
         autofocus: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Input's disabled value.
+         * @type {Boolean}
+         */
+        disabled: {
           type: Boolean,
           value: false
         },


### PR DESCRIPTION
We have a use case in our add flow where birch-standards-picker needs to be disabled. If a person is marked as living, then the date and place inputs for the death and burial conclusions will need to be disabled. Another PR for birch-standards-picker will be coming shortly.